### PR TITLE
CSV token value import feature

### DIFF
--- a/manifest.example.json
+++ b/manifest.example.json
@@ -27,6 +27,10 @@
     {
       "name": "Inherit Name",
       "command": "inherit-name"
+    },
+    {
+      "name": "Import Token Values",
+      "command": "import-token-values"
     }
   ],
   "relaunchButtons": [

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "webpack-cli": "^4.7.0"
   },
   "dependencies": {
+    "hex-rgb": "4.1.0",
     "svelte": "^3.38.2",
     "unique-names-generator": "^4.5.0"
   },

--- a/src/App.ts
+++ b/src/App.ts
@@ -623,9 +623,10 @@ export default class App {
    *
    * @kind function
    * @name createPaintStyles
-   *
    * @param {string} styles The unprocessed string of style names and values,
    * in CSV format.
+   *
+   * @returns {null}
    */
   static createPaintStyles(styles) {
     // quick & dirty CSV parsing - no special parsing
@@ -643,7 +644,7 @@ export default class App {
 
     parsedValues.forEach((style) => {
       const [styleName, styleValue] = style;
-      const parsedStyleValue = parseStyleValue(styleValue);
+      const parsedStyleValue: RGBA = parseStyleValue(styleValue);
 
       const figmaPaintStyle: PaintStyle = figma.createPaintStyle();
       figmaPaintStyle.name = styleName;
@@ -654,16 +655,19 @@ export default class App {
         b: parsedStyleValue.b,
       };
 
+      const opacity = (typeof parsedStyleValue.a === 'number') ? parsedStyleValue.a : 1;
       const solidPaint: SolidPaint = {
         type: 'SOLID',
         color: styleColor,
-        opacity: parsedStyleValue.a || 1,
+        opacity,
       };
 
       figmaPaintStyle.paints = [solidPaint];
     });
 
     messenger.toast(`${parsedValues.length} color styles updated.`);
+
+    return null;
   }
 
   /**

--- a/src/App.ts
+++ b/src/App.ts
@@ -565,7 +565,7 @@ export default class App {
       const parsedStyleValue = parseStyleValue(styleValue);
 
       const figmaPaintStyle = figma.createPaintStyle();
-      figmaPaintStyle.name = styleName.replace(/-/gi, '/');
+      figmaPaintStyle.name = styleName;
 
       const styleColor: RGB = {
         r: parsedStyleValue.r,

--- a/src/App.ts
+++ b/src/App.ts
@@ -71,13 +71,13 @@ const assemble = (context: any = null) => {
 // };
 
 /**
- * @description Retrieves the current options saved to `clientStorage`. If none exist,
+ * Retrieves the current options saved to `clientStorage`. If none exist,
  * defaults are set.
  *
  * @kind function
  * @name getOptions
  *
- * @returns {Object} Returns the options (currently `currentView` and `isMercadoMode`.
+ * @returns {Object} Returns the options (currently `currentView` and `isMercadoMode`).
  */
 const getOptions = async (): Promise<PluginOptions> => {
   // set default options
@@ -90,14 +90,14 @@ const getOptions = async (): Promise<PluginOptions> => {
 
   // retrieve last used, and use if they exist
   const lastUsedOptions: PluginOptions = await figma.clientStorage.getAsync(DATA_KEYS.options);
-  if (lastUsedOptions !== undefined) {
+  if (lastUsedOptions) {
     options = lastUsedOptions;
   }
 
   // check for defaults
   const { currentView }: { currentView: PluginViewTypes } = options;
 
-  if ((currentView === undefined) || (currentView === null)) {
+  if (!currentView) {
     options.currentView = 'general';
   }
 
@@ -493,13 +493,9 @@ export default class App {
         GUI_SETTINGS.default.width,
         newGUIHeight,
       );
-    }
-
-    // log current action
-    if (currentView === 'general') {
       messenger.log(`Updating the UI with ${nodes.length} selected ${nodes.length === 1 ? 'node' : 'nodes'}`);
     } else {
-      messenger.log('Updating the UI with the Token Import');
+      messenger.log('Updating the UI with Token Import');
     }
   }
 
@@ -626,12 +622,12 @@ export default class App {
    * paint styles in the file.
    *
    * @kind function
-   * @name displayStyleValues
+   * @name createPaintStyles
    *
    * @param {string} styles The unprocessed string of style names and values,
    * in CSV format.
    */
-  static displayStyleValues(styles) {
+  static createPaintStyles(styles) {
     // quick & dirty CSV parsing - no special parsing
     function CSVToArray(strData) {
       return strData.split('\n').map((line) => {
@@ -640,6 +636,8 @@ export default class App {
         return [first, second];
       });
     }
+
+    const { messenger } = assemble(figma);
 
     // parse CSV & remove header row
     const parsedValues = CSVToArray(styles).slice(1);
@@ -665,6 +663,8 @@ export default class App {
 
       figmaPaintStyle.paints = [solidPaint];
     });
+
+    messenger.toast(`${parsedValues.length} color styles updated.`);
   }
 
   /**

--- a/src/App.ts
+++ b/src/App.ts
@@ -540,12 +540,14 @@ export default class App {
   }
 
   /**
-   * Draws a colored rectangle for a color swatch.
+   * Parses CSV list of style names and values and creates corresponding Figma
+   * paint styles in the file.
    *
    * @kind function
    * @name displayStyleValues
    *
-   * @param {string} styles The unprocessed string of style names and values, in CSV format.
+   * @param {string} styles The unprocessed string of style names and values,
+   * in CSV format.
    */
   static displayStyleValues(styles) {
     // quick & dirty CSV parsing - no special parsing

--- a/src/App.ts
+++ b/src/App.ts
@@ -629,13 +629,12 @@ export default class App {
    */
   static createPaintStyles(styles) {
     // quick & dirty CSV parsing - no special parsing
-    function CSVToArray(strData) {
-      return strData.split('\n').map((line) => {
-        const [first, ...rest] = line.split(',');
-        const second = rest.join(',');
-        return [first, second];
-      });
-    }
+    const CSVToArray = (strData) => strData.split('\n').map((line) => {
+      // since token names won't have commas but values might, split only on the first comma
+      const [first, ...rest] = line.split(',');
+      const second = rest.join(',');
+      return [first, second];
+    });
 
     const { messenger } = assemble(figma);
 
@@ -646,7 +645,7 @@ export default class App {
       const [styleName, styleValue] = style;
       const parsedStyleValue = parseStyleValue(styleValue);
 
-      const figmaPaintStyle = figma.createPaintStyle();
+      const figmaPaintStyle: PaintStyle = figma.createPaintStyle();
       figmaPaintStyle.name = styleName;
 
       const styleColor: RGB = {

--- a/src/App.ts
+++ b/src/App.ts
@@ -3,7 +3,7 @@ import Editor from './Editor';
 import Painter from './Painter';
 import Presenter from './Presenter';
 import Messenger from './Messenger';
-import { resizeGUI } from './Tools';
+import { parseStyleValue, resizeGUI } from './Tools';
 import { DATA_KEYS, GUI_SETTINGS } from './constants';
 
 /**
@@ -537,6 +537,50 @@ export default class App {
 
     await App.refreshGUI(sessionKey);
     App.showGUI({ messenger });
+  }
+
+  /**
+   * Draws a colored rectangle for a color swatch.
+   *
+   * @kind function
+   * @name displayStyleValues
+   *
+   * @param {string} styles The unprocessed string of style names and values, in CSV format.
+   */
+  static displayStyleValues(styles) {
+    // quick & dirty CSV parsing - no special parsing
+    function CSVToArray(strData) {
+      return strData.split('\n').map((line) => {
+        const [first, ...rest] = line.split(',');
+        const second = rest.join(',');
+        return [first, second];
+      });
+    }
+
+    // parse CSV & remove header row
+    const parsedValues = CSVToArray(styles).slice(1);
+
+    parsedValues.forEach((style) => {
+      const [styleName, styleValue] = style;
+      const parsedStyleValue = parseStyleValue(styleValue);
+
+      const figmaPaintStyle = figma.createPaintStyle();
+      figmaPaintStyle.name = styleName.replace(/-/gi, '/');
+
+      const styleColor: RGB = {
+        r: parsedStyleValue.r,
+        g: parsedStyleValue.g,
+        b: parsedStyleValue.b,
+      };
+
+      const solidPaint: SolidPaint = {
+        type: 'SOLID',
+        color: styleColor,
+        opacity: parsedStyleValue.a || 1,
+      };
+
+      figmaPaintStyle.paints = [solidPaint];
+    });
   }
 
   /**

--- a/src/GUI.ts
+++ b/src/GUI.ts
@@ -38,6 +38,7 @@ const sendLoadedMsg = (): void => {
  * @kind function
  * @name updateSelected
  *
+ * @param {string} currentView A string representing what view to show the user in the UI.
  * @param {Object} selected An object containing `items`, `groups`, and `types` arrays
  * formatted for presentation in the UI.
  * @param {Array} selected.items An array of selected items formatted for presentation

--- a/src/Tools.ts
+++ b/src/Tools.ts
@@ -953,12 +953,12 @@ const checkFilterMatch = (
  * value ([0, 1]) for Figma.
  *
  * @kind function
- * @name convertHexToDecimal
- * @param {RGBA} hexValue A hex value tuple with RGB values from [0, 255].
+ * @name convertRgbToDecimal
+ * @param {Object} hexValue RGBA tuple with RGB values from [0, 255].
  *
- * @returns {RGBA} RGBA tuple with values from [0, 1].
+ * @returns {Object} RGBA tuple with values from [0, 1].
  */
-const convertHexToDecimal = (hexValue: RGBA): RGBA => {
+const convertRgbToDecimal = (hexValue: RGBA): RGBA => {
   const decimal = {
     r: (hexValue.r / 255),
     g: (hexValue.g / 255),
@@ -970,15 +970,14 @@ const convertHexToDecimal = (hexValue: RGBA): RGBA => {
 };
 
 /**
- * Converts an rgba color value encoded in hexademical ([0, 255]) to a decimal
- * value ([0, 1]) for Figma.
+ * Converts a string representation of a hex color into RGBA values ([0, 1]) for Figma.
  *
  * @kind function
  * @name hexToDecimalRgb
  * @param {string} hexColor A string representation of a hexademical color value (e.g. '#FFFFFF').
  * @param {number} opacity A value for opacity between [0, 1].
  *
- * @returns {RGBA} RGBA tuple with values from [0, 1].
+ * @returns {Object} RGBA tuple with values from [0, 1].
  */
 const hexToDecimalRgb = (hexColor: string, opacity?: number): RGBA => {
   const rgbColor: {
@@ -990,7 +989,7 @@ const hexToDecimalRgb = (hexColor: string, opacity?: number): RGBA => {
   const {
     red: r, green: g, blue: b, alpha: a,
   } = rgbColor;
-  const decimalRgb: RGBA = convertHexToDecimal({
+  const decimalRgb: RGBA = convertRgbToDecimal({
     r, g, b, a,
   });
 
@@ -1005,7 +1004,7 @@ const hexToDecimalRgb = (hexColor: string, opacity?: number): RGBA => {
  * @name parseStyleValue
  * @param {string} styleValue A string encoding style information in various formats.
  *
- * @returns {RGBA} RGBA tuple with 'rgb' values from [0, 255] and 'a' value from [0, 1].
+ * @returns {Object} RGBA tuple with 'rgb' values from [0, 255] and 'a' value from [0, 1].
  */
 const parseStyleValue = (styleValue: string): RGBA => {
   let parsedStyleValue;
@@ -1025,7 +1024,7 @@ const parseStyleValue = (styleValue: string): RGBA => {
       .slice(5, -1) // take off rgba and parens
       .split(',');
 
-    parsedStyleValue = convertHexToDecimal({
+    parsedStyleValue = convertRgbToDecimal({
       r: parseInt(colorTuple[0], 10), // int [0, 255]
       g: parseInt(colorTuple[1], 10),
       b: parseInt(colorTuple[2], 10),

--- a/src/Tools.ts
+++ b/src/Tools.ts
@@ -978,15 +978,9 @@ const hexToDecimalRgb = (hexColor: string, opacity?: number): {
   const a: number = rgbColor.alpha || opacity || 1;
 
   const decimalRgb: {
-    r: number,
-    g: number,
-    b: number,
-    a: number
+    r: number, g: number, b: number, a: number
   } = {
-    r,
-    g,
-    b,
-    a,
+    r, g, b, a,
   };
 
   return decimalRgb;

--- a/src/Tools.ts
+++ b/src/Tools.ts
@@ -948,12 +948,17 @@ const checkFilterMatch = (
   return isMatch;
 };
 
-const convertHexToDecimal = (hexValue: {
-  r: number,
-  g: number,
-  b: number,
-  a: number,
-}) => {
+/**
+ * Converts an rgba color value encoded in hexademical ([0, 255]) to a decimal
+ * value ([0, 1]) for Figma.
+ *
+ * @kind function
+ * @name convertHexToDecimal
+ * @param {RGBA} hexValue A hex value tuple with RGB values from [0, 255].
+ *
+ * @returns {RGBA} RGBA tuple with values from [0, 1].
+ */
+const convertHexToDecimal = (hexValue: RGBA): RGBA => {
   const decimal = {
     r: (hexValue.r / 255),
     g: (hexValue.g / 255),
@@ -964,32 +969,49 @@ const convertHexToDecimal = (hexValue: {
   return decimal;
 };
 
-const hexToDecimalRgb = (hexColor: string, opacity?: number): {
-  r: number,
-  g: number,
-  b: number,
-  a: number
-} => {
-  const rgbColor: { red: number, green: number, blue: number, alpha: number } = hexRgb(hexColor);
+/**
+ * Converts an rgba color value encoded in hexademical ([0, 255]) to a decimal
+ * value ([0, 1]) for Figma.
+ *
+ * @kind function
+ * @name hexToDecimalRgb
+ * @param {string} hexColor A string representation of a hexademical color value (e.g. '#FFFFFF').
+ * @param {number} opacity A value for opacity between [0, 1].
+ *
+ * @returns {RGBA} RGBA tuple with values from [0, 1].
+ */
+const hexToDecimalRgb = (hexColor: string, opacity?: number): RGBA => {
+  const rgbColor: {
+    red: number, green: number, blue: number, alpha: number,
+  } = hexRgb(hexColor, {
+    alpha: opacity,
+  });
 
-  const r: number = (rgbColor.red / 255);
-  const g: number = (rgbColor.green / 255);
-  const b: number = (rgbColor.blue / 255);
-  const a: number = rgbColor.alpha || opacity || 1;
-
-  const decimalRgb: {
-    r: number, g: number, b: number, a: number
-  } = {
+  const {
+    red: r, green: g, blue: b, alpha: a,
+  } = rgbColor;
+  const decimalRgb: RGBA = convertHexToDecimal({
     r, g, b, a,
-  };
+  });
 
   return decimalRgb;
 };
 
-const parseStyleValue = (styleValue: string) => {
+/**
+ * Converts a color value encoded either in hexademical, rgba tuple, or with
+ * value 'transparent' into an RGBA value.
+ *
+ * @kind function
+ * @name parseStyleValue
+ * @param {string} styleValue A string encoding style information in various formats.
+ *
+ * @returns {RGBA} RGBA tuple with 'rgb' values from [0, 255] and 'a' value from [0, 1].
+ */
+const parseStyleValue = (styleValue: string): RGBA => {
   let parsedStyleValue;
+
   if (styleValue === 'transparent') {
-    // if value is "transparent"
+    // if value is the string literal 'transparent'
     parsedStyleValue = {
       r: 0,
       g: 0,

--- a/src/additionalTypes.d.ts
+++ b/src/additionalTypes.d.ts
@@ -5,7 +5,8 @@ declare global {
     | 'Grid'
     | 'Typography'
     | 'Color & Fill'
-    | 'Component';
+    | 'Component'
+    | 'Style Import';
 
   type PresenterTypeGroup = {
     id: string,

--- a/src/additionalTypes.d.ts
+++ b/src/additionalTypes.d.ts
@@ -5,8 +5,7 @@ declare global {
     | 'Grid'
     | 'Typography'
     | 'Color & Fill'
-    | 'Component'
-    | 'Style Import';
+    | 'Component';
 
   type PresenterTypeGroup = {
     id: string,

--- a/src/assets/css/components/_style-import.scss
+++ b/src/assets/css/components/_style-import.scss
@@ -12,7 +12,7 @@
   }
 
   button {
-    @include figma-button;
+    @include figma-button--primary;
     float: right;
     margin-top: em(10);
   }

--- a/src/assets/css/components/_style-import.scss
+++ b/src/assets/css/components/_style-import.scss
@@ -1,0 +1,27 @@
+// ++++++++++++++++++++++++++++++++++++++++++++++ blank state component
+
+@mixin style-import {
+  // display: flex;
+  // flex-direction: row;
+  // justify-content: space-between;
+  align-items: center;
+  margin: 0;
+  padding: em(30) 14% em(0) 14%;
+
+  span {
+    display: block;
+
+    &.mark {
+      flex-basis: 20%;
+    }
+
+    &.text {
+      flex-basis: 65%;
+      @include type-03;
+    }
+  }
+}
+
+.style-import {
+  @include style-import;
+}

--- a/src/assets/css/components/_style-import.scss
+++ b/src/assets/css/components/_style-import.scss
@@ -1,24 +1,24 @@
 // ++++++++++++++++++++++++++++++++++++++++++++++ blank state component
 
 @mixin style-import {
-  // display: flex;
-  // flex-direction: row;
-  // justify-content: space-between;
   align-items: center;
   margin: 0;
   padding: em(30) 14% em(0) 14%;
 
-  span {
+  textarea {
     display: block;
+    height: em(300);
+    width: 100%;
+  }
 
-    &.mark {
-      flex-basis: 20%;
-    }
+  button {
+    @include figma-button;
+    float: right;
+    margin-top: em(10);
+  }
 
-    &.text {
-      flex-basis: 65%;
-      @include type-03;
-    }
+  h1 {
+    @include type-03;
   }
 }
 

--- a/src/assets/css/main.scss
+++ b/src/assets/css/main.scss
@@ -25,4 +25,5 @@
 @import "components/status-bar";
 @import "components/list-headers";
 @import "components/blank-state";
+@import "components/style-import";
 @import "components/content-layer-holder";

--- a/src/code.ts
+++ b/src/code.ts
@@ -86,7 +86,7 @@ const dispatcher = async (action: {
         app.handleUpdate(payload, sessionKey);
         break;
       case 'sendStyleValues':
-        App.displayStyleValues(payload);
+        App.createPaintStyles(payload);
         break;
       case 'import-token-values':
         App.showTokenImport(sessionKey);

--- a/src/code.ts
+++ b/src/code.ts
@@ -110,6 +110,13 @@ const dispatcher = async (action: {
       case 'submit-bulk':
         app.handleUpdate(payload, sessionKey);
         break;
+      case 'sendStyleValues':
+        App.displayStyleValues(payload);
+        break;
+      case 'import-token-values':
+        // THROW CSV IMPORT WINDOW
+        App.showGUI({});
+        break;
       case 'tools':
         App.showToolbar(sessionKey);
         break;

--- a/src/views/App.svelte
+++ b/src/views/App.svelte
@@ -11,6 +11,7 @@
   import ItemsList from './ItemsList';
   import SceneNavigator from './SceneNavigator';
   import StatusBar from './StatusBar';
+  import StyleImport from './StyleImport';
 
   export let filter = 'all-components';
   export let inspect = 'components';
@@ -41,7 +42,7 @@
     setCurrentFilter(filter);
     sessionKey.set(newSessionKey);
 
-    if (wasBodyHeight !== bodyHeight && selected.items.length > 0) {
+    if (wasBodyHeight !== bodyHeight && selected && selected.items.length > 0) {
       parent.postMessage({
         pluginMessage: {
           action: 'resize',
@@ -67,6 +68,7 @@
   {#if selected && selected.items.length > 0}
     <ItemsList selected={selected}/>
   {:else}
+    <StyleImport />
     <BlankState isStyles={$isStyles}/>
   {/if}
 

--- a/src/views/SceneNavigator.svelte
+++ b/src/views/SceneNavigator.svelte
@@ -52,6 +52,11 @@
       id: 'grid',
       type: 'styles',
     },
+    {
+      text: 'Style Import',
+      id: 'style-import',
+      type: 'styles',
+    },
   ];
 
   const setCurrentFilters = (newIsStyles, newFilter) => {

--- a/src/views/SceneNavigator.svelte
+++ b/src/views/SceneNavigator.svelte
@@ -52,11 +52,6 @@
       id: 'grid',
       type: 'styles',
     },
-    {
-      text: 'Style Import',
-      id: 'style-import',
-      type: 'styles',
-    },
   ];
 
   const setCurrentFilters = (newIsStyles, newFilter) => {

--- a/src/views/StyleImport.svelte
+++ b/src/views/StyleImport.svelte
@@ -1,0 +1,22 @@
+<script>
+  let value = '';
+
+  const importStyleCSV = (styles) => {
+    parent.postMessage({
+      pluginMessage: {
+        action: 'sendStyleValues',
+        payload: styles,
+      },
+    }, '*');
+  };
+</script>
+
+<aside class="style-import" id="style-import">
+  <h1>Import style CSV</h1>
+  <textarea placeholder={'Paste style CSV values here...'} bind:value={value}></textarea>
+  <button 
+    on:click={() => importStyleCSV(value)}
+  >
+    Import
+  </button>
+</aside>

--- a/src/views/StyleImport.svelte
+++ b/src/views/StyleImport.svelte
@@ -12,9 +12,9 @@
 </script>
 
 <aside class="style-import" id="style-import">
-  <h1>Import style CSV</h1>
-  <textarea placeholder={'Paste style CSV values here...'} bind:value={value}></textarea>
-  <button 
+  <h1>Import color style tokens CSV</h1>
+  <textarea placeholder={'Paste color token CSV values here...'} bind:value={value}></textarea>
+  <button
     on:click={() => importStyleCSV(value)}
   >
     Import

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,10 @@
       "node",
       "@pyoner/svelte-types",
       "@figma/plugin-typings"
+    ],
+    "typeRoots": [
+      "./node_modules/@types",
+      "./node_modules/@figma"
     ]
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,9 +6,5 @@
       "@pyoner/svelte-types",
       "@figma/plugin-typings"
     ],
-    "typeRoots": [
-      "./node_modules/@types",
-      "./node_modules/@figma"
-    ]
   }
 }


### PR DESCRIPTION
This PR makes the following changes:
- Adds a "Import Token Values" menu option with CSV import window
- CSV import window accepts raw CSV string and converts into Figma styles (`PaintStyle`s)

<img width="1680" alt="Screen Shot 2021-06-10 at 10 19 22 PM" src="https://user-images.githubusercontent.com/2928395/121634778-0a05d380-ca3a-11eb-94b8-85d58780ddbf.png">
<img width="1680" alt="Screen Shot 2021-06-10 at 10 19 35 PM" src="https://user-images.githubusercontent.com/2928395/121634781-0b370080-ca3a-11eb-84ac-31d72a7acd20.png">
