### PR TITLE
Token Import: UI Switching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
+        "hex-rgb": "4.1.0",
         "svelte": "^3.38.2",
         "unique-names-generator": "^4.5.0"
       },
@@ -5260,6 +5261,14 @@
       "dev": true,
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/hex-rgb": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.1.0.tgz",
+      "integrity": "sha512-n7xsIfyBkFChITGPh6FLtxNzAt2HxZLcQIY9hYH4gm2gmMQJHMguMH3E+jnmvUbSTF5QrmFnGab5Ippi+D7e/g==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/hmac-drbg": {
@@ -17555,6 +17564,11 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
+    },
+    "hex-rgb": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.1.0.tgz",
+      "integrity": "sha512-n7xsIfyBkFChITGPh6FLtxNzAt2HxZLcQIY9hYH4gm2gmMQJHMguMH3E+jnmvUbSTF5QrmFnGab5Ippi+D7e/g=="
     },
     "hmac-drbg": {
       "version": "1.0.1",

--- a/src/App.ts
+++ b/src/App.ts
@@ -539,6 +539,23 @@ export default class App {
     App.showGUI({ messenger });
   }
 
+  /** WIP
+   * Triggers a UI refresh and then displays the plugin UI.
+   *
+   * @kind function
+   * @name showTokenImport
+   *
+   * @param {string} sessionKey A rotating key used during the single run of the plugin.
+   */
+  static async showTokenImport() {
+    const { messenger } = assemble(figma);
+
+    App.showGUI({
+      size: 'tokenImport',
+      messenger,
+    });
+  }
+
   /**
    * Parses CSV list of style names and values and creates corresponding Figma
    * paint styles in the file.
@@ -602,7 +619,10 @@ export default class App {
    * @returns {null}
    */
   static async showGUI(options: {
-    size?: 'default' | 'info',
+    size?:
+      'default'
+      | 'info'
+      | 'tokenImport',
     messenger?: { log: Function },
   }) {
     const { size, messenger } = options;

--- a/src/GUI.ts
+++ b/src/GUI.ts
@@ -4,6 +4,7 @@ import App from './views/App.svelte'; // eslint-disable-line import/extensions
 const app = new App({
   target: document.body,
   props: {
+    currentView: 'general',
     inspect: 'styles',
     filter: 'all-styles',
     selected: null,
@@ -59,6 +60,7 @@ const sendLoadedMsg = (): void => {
  * @returns {null}
  */
 const updateSelected = (
+  currentView: PluginViewTypes,
   selected: {
     items: Array<PresenterItem>,
     groups: Array<PresenterTypeGroup>,
@@ -71,6 +73,10 @@ const updateSelected = (
   },
   sessionKey: string,
 ): void => {
+  if (currentView) {
+    app.currentView = currentView;
+  }
+
   if (selected) {
     app.selected = selected;
   }
@@ -113,11 +119,21 @@ const watchIncomingMessages = (): void => {
     const { pluginMessage } = event.data;
     if (pluginMessage) {
       const { payload } = pluginMessage;
-      const { filters, selected, sessionKey } = payload;
+      const {
+        currentView,
+        filters,
+        selected,
+        sessionKey,
+      } = payload;
 
       switch (pluginMessage.action) {
         case 'refreshState':
-          updateSelected(selected, filters, sessionKey);
+          updateSelected(
+            currentView,
+            selected,
+            filters,
+            sessionKey,
+          );
           break;
         default:
           return null;

--- a/src/additionalTypes.d.ts
+++ b/src/additionalTypes.d.ts
@@ -1,5 +1,9 @@
 declare global {
   // Internal Declarations
+  type PluginViewTypes = 
+    'general'
+    | 'token-import';
+
   type PresenterTypeName =
     'Effect'
     | 'Grid'
@@ -59,6 +63,13 @@ declare global {
     visible: boolean,
     invisible: string
   }
+
+  type PluginOptions = {
+    isSelection: boolean,
+    isStyles: boolean,
+    filter: string,
+    currentView: PluginViewTypes,
+  };
 
   // Vendor Declarations
 

--- a/src/code.ts
+++ b/src/code.ts
@@ -62,31 +62,6 @@ const dispatcher = async (action: {
 
   // run the action in the App class based on type
   const runAction = async () => {
-    // retrieve existing options
-    // const lastUsedOptions: {
-    //   action: 'duplicate' | 'replace' | 'new-page',
-    //   translateLocked: boolean,
-    //   languages: Array<string>,
-    // } = await figma.clientStorage.getAsync(DATA_KEYS.options);
-
-    // // make sure the type passed from the menu command exists
-    // const verifyQuickType = (kind: string, quickType: string): boolean => {
-    //   const typeSimplified = quickType.replace(`quick-${kind}-`, '');
-    //   let isVerified = false;
-
-    //   if (typeSimplified === 'assigned') {
-    //     isVerified = true;
-    //     return isVerified;
-    //   }
-
-    //   Object.keys(ASSIGNMENTS).forEach((key) => {
-    //     if (ASSIGNMENTS[key].id === typeSimplified) {
-    //       isVerified = true;
-    //     }
-    //   });
-    //   return isVerified;
-    // };
-
     switch (type) {
       case 'detach-instances':
         app.detachInstances(sessionKey);

--- a/src/code.ts
+++ b/src/code.ts
@@ -114,7 +114,7 @@ const dispatcher = async (action: {
         App.displayStyleValues(payload);
         break;
       case 'import-token-values':
-        App.showTokenImport();
+        App.showTokenImport(sessionKey);
         break;
       case 'tools':
         App.showToolbar(sessionKey);

--- a/src/code.ts
+++ b/src/code.ts
@@ -114,8 +114,7 @@ const dispatcher = async (action: {
         App.displayStyleValues(payload);
         break;
       case 'import-token-values':
-        // THROW CSV IMPORT WINDOW
-        App.showGUI({});
+        App.showTokenImport();
         break;
       case 'tools':
         App.showToolbar(sessionKey);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -150,6 +150,10 @@ const GUI_SETTINGS = {
     width: 200,
     height: 324,
   },
+  tokenImport: {
+    width: 360,
+    height: 200,
+  },
 };
 
 export {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -152,7 +152,7 @@ const GUI_SETTINGS = {
   },
   tokenImport: {
     width: 360,
-    height: 250,
+    height: 450,
   },
 };
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -152,7 +152,7 @@ const GUI_SETTINGS = {
   },
   tokenImport: {
     width: 360,
-    height: 200,
+    height: 250,
   },
 };
 

--- a/src/views/App.svelte
+++ b/src/views/App.svelte
@@ -13,6 +13,7 @@
   import StatusBar from './StatusBar';
   import StyleImport from './StyleImport';
 
+  export let currentView = 'general';
   export let filter = 'all-components';
   export let inspect = 'components';
   export let newSessionKey = null;
@@ -63,14 +64,18 @@
 <!-- core layout -->
 <div bind:offsetHeight={bodyHeight}>
   <FontPreload/>
-  <SceneNavigator />
 
-  {#if selected && selected.items.length > 0}
-    <ItemsList selected={selected}/>
+  {#if currentView === 'general'}
+    <SceneNavigator />
+
+    {#if selected && selected.items.length > 0}
+      <ItemsList selected={selected}/>
+    {:else}
+      <BlankState isStyles={$isStyles}/>
+    {/if}
+
+    <StatusBar numberSelected={selected ? selected.items.length : 0}/>
   {:else}
     <StyleImport />
-    <BlankState isStyles={$isStyles}/>
   {/if}
-
-  <StatusBar numberSelected={selected ? selected.items.length : 0}/>
 </div>


### PR DESCRIPTION
Leverage our existing `options` bundle and UI routing (through `refreshGUI`) and add `currentView` to allow for displaying an entirely separate UI for the Token Import feature.